### PR TITLE
Fix regole validazione

### DIFF
--- a/FatturaElettronicaBody/DatiGenerali/DatiCassaPrevidenziale.cs
+++ b/FatturaElettronicaBody/DatiGenerali/DatiCassaPrevidenziale.cs
@@ -18,7 +18,7 @@ namespace FatturaElettronicaPA.FatturaElettronicaBody.DatiGenerali
             var rules = base.CreateRules();
             rules.Add(new AndCompositeValidator("TipoCassa", new List<Validator>{new FRequiredValidator(), new FTipoCassaValidator()}));
             rules.Add(new FRequiredValidator("AlCassa"));
-            rules.Add(new FRequiredValidator("ImportContributoCassa"));
+            rules.Add(new FRequiredValidator("ImportoContributoCassa"));
             rules.Add(new FRequiredValidator("AliquotaIVA"));
             rules.Add(new FNaturaValidator("Natura"));
             rules.Add(new FLengthValidator("RiferimentoAmministrazione", 1, 20));

--- a/FatturaElettronicaBody/DatiGenerali/DatiGeneraliDocumento.cs
+++ b/FatturaElettronicaBody/DatiGenerali/DatiGeneraliDocumento.cs
@@ -36,7 +36,7 @@ namespace FatturaElettronicaPA.FatturaElettronicaBody.DatiGenerali
             var rules = base.CreateRules();
             rules.Add(new AndCompositeValidator("TipoDocumento", new List<Validator>{new FRequiredValidator(), new FTipoDocumentoValidator()}));
             rules.Add(new AndCompositeValidator("Divisa", new List<Validator>{new FRequiredValidator(), new FDivisaValidator()}));
-            rules.Add(new AndCompositeValidator("Data", new List<Validator>{new FRequiredValidator(), new FDateValidator()}));
+            rules.Add(new AndCompositeValidator("Data", new List<Validator>{new FRequiredValidator()}));
             rules.Add(new AndCompositeValidator("Numero", new List<Validator>{new FRequiredValidator(), new FLengthValidator(1,20)}));
             rules.Add(new FSiValidator("Art73"));
             return rules;

--- a/FatturaElettronicaBody/DatiGenerali/DatiGeneraliDocumento.cs
+++ b/FatturaElettronicaBody/DatiGenerali/DatiGeneraliDocumento.cs
@@ -36,7 +36,7 @@ namespace FatturaElettronicaPA.FatturaElettronicaBody.DatiGenerali
             var rules = base.CreateRules();
             rules.Add(new AndCompositeValidator("TipoDocumento", new List<Validator>{new FRequiredValidator(), new FTipoDocumentoValidator()}));
             rules.Add(new AndCompositeValidator("Divisa", new List<Validator>{new FRequiredValidator(), new FDivisaValidator()}));
-            rules.Add(new AndCompositeValidator("Data", new List<Validator>{new FRequiredValidator()}));
+            rules.Add(new FRequiredValidator("Data"));
             rules.Add(new AndCompositeValidator("Numero", new List<Validator>{new FRequiredValidator(), new FLengthValidator(1,20)}));
             rules.Add(new FSiValidator("Art73"));
             return rules;

--- a/FatturaElettronicaBody/DatiGenerali/DatiRitenuta.cs
+++ b/FatturaElettronicaBody/DatiGenerali/DatiRitenuta.cs
@@ -19,7 +19,6 @@ namespace FatturaElettronicaPA.FatturaElettronicaBody.DatiGenerali
             rules.Add(new AndCompositeValidator("TipoRitenuta", new List<Validator>{new FRequiredValidator(), new FTipoRitenutaValidator()}));
             rules.Add(new FRequiredValidator("ImportoRitenuta"));
             rules.Add(new FRequiredValidator("AliquotaRitenuta"));
-            rules.Add(new FSiValidator());
             rules.Add(new AndCompositeValidator("CausalePagamento", new List<Validator>{new FRequiredValidator(), new FCausalePagamentoValidator()}));
             return rules;
         }

--- a/FatturaElettronicaBody/DatiGenerali/DatiTrasporto.cs
+++ b/FatturaElettronicaBody/DatiGenerali/DatiTrasporto.cs
@@ -24,14 +24,10 @@ namespace FatturaElettronicaPA.FatturaElettronicaBody.DatiGenerali
         }
         public DatiTrasporto(XmlReader r) : base(r) { }
 
+        // TODO: Implementare le regole per i DatiTrasporto
         protected override List<Validator> CreateRules() {
             var rules = base.CreateRules();
-            rules.Add(new AndCompositeValidator("TipoCassa", new List<Validator>{new FRequiredValidator(), new FTipoCassaValidator()}));
-            rules.Add(new FRequiredValidator("AlCassa"));
-            rules.Add(new FRequiredValidator("ImportContributoCassa"));
-            rules.Add(new FRequiredValidator("AliquotaIVA"));
-            rules.Add(new FNaturaValidator("Natura"));
-            rules.Add(new FLengthValidator("RiferimentoAmministrazione", 1, 20));
+            
             return rules;
         }
 


### PR DESCRIPTION
Ciao,
ho trovato diversi errori nelle regole di validazione quando viene invocato IsValid sull'oggetto principale, questo blocca anche la conversione in JSON.
Ho fatto tutti i fix, per rendere funzionate la serializzazione, ma è necessaria una conferma su:
 1. **DatiGeneraliDocumento**: ho visto che faceva uso di un FDateValidator che però si aspettava una stringa facendo poi dei controlli di regex. Ho eliminato la regola.
 1. **Dati Trasporto**: Ho eliminato tutte le regole perché si riferivano ad un altro oggetto. E' necessario implementarle.